### PR TITLE
fix: add CSRF_TRUSTED_ORIGINS env support and gitignore celery beat files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ __pycache__/
 
 # Django migrations (all apps)
 **/migrations/
+
+# Celery Beat scheduler files
+celerybeat-schedule
+celerybeat-schedule-shm
+celerybeat-schedule-wal

--- a/WafControl/settings.py
+++ b/WafControl/settings.py
@@ -39,7 +39,7 @@ SECRET_KEY = env('SECRET_KEY')
 DEBUG = env.bool('DEBUG', False)
 
 ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=['127.0.0.1', 'localhost'])
-
+CSRF_TRUSTED_ORIGINS = env.list('CSRF_TRUSTED_ORIGINS', default=[])
 
 # Application definition
 


### PR DESCRIPTION
WafControl's env.example already documents CSRF_TRUSTED_ORIGINS, however 
the setting was never wired up in settings.py to actually read it from the 
environment variable.

When deploying behind a reverse proxy with a custom domain (e.g. Nginx, 
Cloudflare Tunnel), Django 4.0+ requires CSRF_TRUSTED_ORIGINS to be set. 
Without it, all POST requests fail with a 403 CSRF error despite the variable 
being correctly configured in .env.

This PR adds the missing env.list() call in settings.py, consistent with how 
ALLOWED_HOSTS is already handled, making the documented variable actually work.

Also adds celery beat scheduler files to .gitignore as they are 
auto-generated at runtime and should not be tracked.