### PR TITLE
Fix broken flag image fallback causing ERR_BLOCKED_BY_ORB errors

### DIFF
--- a/wafinstaller/templates/dashboard/panel/attacks.html
+++ b/wafinstaller/templates/dashboard/panel/attacks.html
@@ -104,11 +104,13 @@
                                                 <td>{{ attack.timestamp|date:"Y-m-d H:i:s" }}</td>
                                                 <td>{{ attack.ip }}</td>
                                                 <td>
+                                                    {% if attack.flag and attack.flag != "xx" %}
                                                     <img src="https://flagcdn.com/24x18/{{ attack.flag }}.png"
-                                                         onerror="this.src='https://flagcdn.com/24x18/xx.png';"
+                                                         onerror="this.style.display='none';"
                                                          alt="{{ attack.country }}"
                                                          class="mr-1"
-                                                         style="vertical-align: middle; border-radius: 3px;"><br>
+                                                         style="vertical-align: middle; border-radius: 3px;">
+                                                    {% endif %}<br>
                                                     {{ attack.country }}
                                                 </td>
                                                 <td>{{ attack.rule_id }}</td>

--- a/wafinstaller/templates/dashboard/panel/panel.html
+++ b/wafinstaller/templates/dashboard/panel/panel.html
@@ -390,10 +390,12 @@
                                                 {% endif %}
                                             </td>
                                             <td>
+                                                {% if attack.flag and attack.flag != "xx" %}
                                                 <img src="https://flagcdn.com/24x18/{{ attack.flag }}.png"
-                                                     onerror="this.src='https://flagcdn.com/24x18/xx.png';"
+                                                     onerror="this.style.display='none';"
                                                      alt="{{ attack.country }}"
                                                      style="vertical-align: middle; border-radius: 3px;">
+                                                {% endif %}
                                                 {{ attack.country }}
                                             </td>
                                             <td>{{ attack.rule_id }}</td>

--- a/wafinstaller/templates/dashboard/panel/top_attackers.html
+++ b/wafinstaller/templates/dashboard/panel/top_attackers.html
@@ -40,11 +40,13 @@
                                             <td>{{ forloop.counter }}</td>
                                             <td>{{ attacker.ip }}</td>
                                             <td>
+                                                {% if attacker.flag and attacker.flag|lower != "xx" %}
                                                 <img src="https://flagcdn.com/24x18/{{ attacker.flag|lower }}.png"
-                                                     onerror="this.src='https://flagcdn.com/24x18/xx.png';"
+                                                     onerror="this.style.display='none';"
                                                      alt="{{ attacker.country }}"
                                                      class="mr-1"
                                                      style="vertical-align: middle; border-radius: 3px;">
+                                                {% endif %}
                                                 {{ attacker.country }}
                                             </td>
                                             <td>{{ attacker.total }}</td>


### PR DESCRIPTION
## Summary

- The `onerror` handler on country flag `<img>` elements falls back to `https://flagcdn.com/24x18/xx.png`, which does not exist on flagcdn.com
- This causes repeated `ERR_BLOCKED_BY_ORB` console errors for every attack entry where the country is unknown (`flag="xx"`)
- Affects the dashboard, all attacks, and top attackers pages

## Fix

- Skip rendering the flag `<img>` entirely when the flag code is empty or `"xx"` using a Django template conditional
- Replace the broken `onerror` fallback with `this.style.display='none'` for any remaining load failures

## Files changed

- `wafinstaller/templates/dashboard/panel/panel.html`
- `wafinstaller/templates/dashboard/panel/attacks.html`
- `wafinstaller/templates/dashboard/panel/top_attackers.html`

## How to reproduce

1. Have attack entries from private/unknown IPs (flag stored as `"xx"`)
2. Open the dashboard, attacks, or top attackers page
3. Observe `ERR_BLOCKED_BY_ORB` errors in the browser console for every `xx.png` request