### PR TITLE
USED AI - Fix Apache/CRS path detection and rule-list error handling

### DIFF
--- a/scripts/basic.sh
+++ b/scripts/basic.sh
@@ -18,10 +18,18 @@ is_active() {
   pgrep -f "$svc" >/dev/null 2>&1
 }
 detect_server() {
+  if [[ -f /etc/apache2/mods-enabled/security2.conf && -f /etc/modsecurity/modsecurity.conf ]]; then
+    echo apache
+    return
+  fi
+  if [[ -f /etc/nginx/modsec/main.conf ]]; then
+    echo nginx
+    return
+  fi
   is_active nginx && { echo nginx; return; }
   is_active apache2 && { echo apache; return; }
-  command -v nginx >/dev/null 2>&1 && { echo nginx; return; }
   (command -v apache2ctl >/dev/null 2>&1 || command -v apache2 >/dev/null 2>&1) && { echo apache; return; }
+  command -v nginx >/dev/null 2>&1 && { echo nginx; return; }
   echo none
 }
 get_crs_version_nginx() {
@@ -29,6 +37,11 @@ get_crs_version_nginx() {
   [[ -f "$conf" ]] && grep -Eo 'coreruleset-[0-9]+\.[0-9]+(\.[0-9]+)?' "$conf" | head -n1 | sed 's/coreruleset-//'
 }
 get_crs_version_apache() {
+  local current="/etc/modsecurity/crs/current"
+  if [[ -L "$current" ]]; then
+    readlink -f "$current" | grep -Eo 'coreruleset-([0-9]+\.[0-9]+(\.[0-9]+)?)' | sed 's/coreruleset-//'
+    return
+  fi
   local setup="/etc/modsecurity/crs-setup.conf"
   if [[ -L "$setup" ]]; then
     readlink -f "$setup" | grep -Eo 'modsecurity-crs-([0-9]+\.[0-9]+(\.[0-9]+)?)' | sed 's/.*modsecurity-crs-//'

--- a/wafinstaller/helper/adapters.py
+++ b/wafinstaller/helper/adapters.py
@@ -27,8 +27,8 @@ NGINX_PATHS = Paths(
 APACHE_PATHS = Paths(
     name="apache",
     modsec_conf="/etc/modsecurity/modsecurity.conf",
-    rules_dir_tmpl="/usr/share/modsecurity-crs-{ver}/rules",
-    custom_after_tmpl="/usr/share/modsecurity-crs-{ver}/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf",
+    rules_dir_tmpl="/etc/modsecurity/crs/versions/coreruleset-{ver}/rules",
+    custom_after_tmpl="/etc/modsecurity/crs/versions/coreruleset-{ver}/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf",
     audit_log="/var/log/modsec_audit.log",
     test_cmd=["apache2ctl", "configtest"],
     reload_cmd=["apache2ctl", "-k", "graceful"],
@@ -36,7 +36,7 @@ APACHE_PATHS = Paths(
 
 def _run_basic_script():
     base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    script = os.path.join(base_dir, "../../scripts", "basic.sh")
+    script = os.path.join(os.path.dirname(base_dir), "scripts", "basic.sh")
     try:
         out = subprocess.check_output(["/bin/bash", script], text=True, stderr=subprocess.STDOUT)
         return json.loads(out)
@@ -64,7 +64,14 @@ def detect_crs_version():
                 return m.group(1)
     except Exception:
         pass
-    # Fallback Apache
+    # Fallback Apache: resolve the active CRS version via the "current" symlink
+    try:
+        current = os.path.realpath("/etc/modsecurity/crs/current")
+        m = re.search(r'coreruleset-([0-9]+\.[0-9]+(?:\.[0-9]+)?)', current)
+        if m:
+            return m.group(1)
+    except Exception:
+        pass
     try:
         setup = os.path.realpath("/etc/modsecurity/crs-setup.conf")
         m = re.search(r'modsecurity-crs-([0-9]+\.[0-9]+(?:\.[0-9]+)?)', setup)

--- a/wafinstaller/templates/dashboard/panel/crs_rules.html
+++ b/wafinstaller/templates/dashboard/panel/crs_rules.html
@@ -14,6 +14,9 @@
                             </div>
                         </div>
                         <div class="iq-card-body">
+                            {% if rule_error %}
+                                <div class="alert alert-warning">{{ rule_error }}</div>
+                            {% endif %}
                             {% if rule_files %}
                                 <div class="table-responsive">
                                     <table id="datatable" class="table table-striped table-bordered">

--- a/wafinstaller/views.py
+++ b/wafinstaller/views.py
@@ -438,17 +438,18 @@ class CRSRuleListView(LoginRequiredMixin, TemplateView):
         version = get_crs_full_version()
         rule_dir = get_rules_dir(version)
         files = []
+        rule_error = ""
         try:
             if rule_dir and os.path.isdir(rule_dir):
                 for filename in sorted(os.listdir(rule_dir)):
                     if filename.endswith((".conf", ".data")):
                         files.append(filename)
             else:
-                files.append(f"[Directory not found]: {rule_dir}")
+                rule_error = f"Directory not found: {rule_dir}"
         except Exception as e:
-            files.append(f"[Error]: {str(e)}")
+            rule_error = str(e)
 
-        context.update({"crs_version": version, "rule_files": files})
+        context.update({"crs_version": version, "rule_files": files, "rule_error": rule_error})
         return context
 
 


### PR DESCRIPTION
- detect_server(): check real config presence (Apache vs Nginx) before falling back to binary/service detection, so systems with both nginx and apache2 installed but only apache2 actually serving ModSecurity are detected correctly.
- get_crs_version_apache(): resolve the CRS version via the /etc/modsecurity/crs/current symlink, which is how the Debian/Ubuntu modsecurity-crs package lays out installs (crs-setup.conf is not a symlink in that layout).
- APACHE_PATHS.rules_dir_tmpl / custom_after_tmpl: point at /etc/modsecurity/crs/versions/coreruleset-{ver}/rules instead of the nonexistent /usr/share/modsecurity-crs-{ver}/rules.
- _run_basic_script(): fix broken relative path construction that caused the helper script lookup to fail silently and fall back to Nginx paths on every request.
- CRSRuleListView / crs_rules.html: stop injecting backend path errors as fake filenames into the rule list (clicking them 404'd and broke JSON parsing in the browser); render them as a separate error alert instead.